### PR TITLE
Replaced js syntax commenting with coffeescript syntax

### DIFF
--- a/root/Gruntfile.coffee
+++ b/root/Gruntfile.coffee
@@ -1,10 +1,10 @@
-/*
- * {%= name %}
- * {%= homepage %}
- *
- * Copyright (c) {%= grunt.template.today('yyyy') %} {%= author_name %}
- * Licensed under the {%= licenses.join(', ') %} license{%= licenses.length === 1 ? '' : 's' %}.
- */
+###
+{%= name %}
+{%= homepage %}
+
+Copyright (c) {%= grunt.template.today('yyyy') %} {%= author_name %}
+Licensed under the {%= licenses.join(', ') %} license{%= licenses.length === 1 ? '' : 's' %}.
+###
 
 module.exports = (grunt)->
   'use strict'


### PR DESCRIPTION
Replaced js syntax of commenting because it will give you an error when trying to compile the coffeescript
